### PR TITLE
Fix put stream if directory is missing

### DIFF
--- a/src/webdavfilez.erl
+++ b/src/webdavfilez.erl
@@ -228,8 +228,10 @@ put(Config, Url0, {filename, Size, Filename}, Opts) ->
     end.
 
 put_body_file({file, Filename}) ->
-    {ok, FD} = file:open(Filename, [read,binary]),
-    put_body_file({fd, FD});
+    case file:open(Filename, [read,binary]) of
+        {ok, FD} -> put_body_file({fd, FD});
+        {error, _} -> eof
+    end;
 put_body_file({fd, FD}) ->
     case file:read(FD, ?BLOCK_SIZE) of
         eof ->
@@ -255,7 +257,7 @@ opts_to_headers(Opts) ->
                     % Ignore S3 ACL options
                     Hs;
               ({content_type, CT}, Hs) ->
-                    [{"Content-Type", CT} | Hs];
+                    [{"Content-Type", to_list(CT)} | Hs];
               (Unknown, _) ->
                     throw({error, {unknown_option, Unknown}})
            end,
@@ -292,4 +294,7 @@ map_url("webdav:" ++ Rest) -> "http:" ++ Rest;
 map_url("davs:" ++ Rest) -> "https:" ++ Rest;
 map_url("dav:" ++ Rest) -> "http:" ++ Rest;
 map_url(Url) -> Url.
+
+to_list(B) when is_binary(B) -> binary_to_list(B);
+to_list(L) when is_list(L) -> L.
 

--- a/src/webdavfilez.erl
+++ b/src/webdavfilez.erl
@@ -207,7 +207,7 @@ put(Config, Url0, {filename, Size, Filename}, Opts) ->
     case Ret of
         ok ->
             ok;
-        {error, 409} ->
+        {error, Err} when Err =:= 409; Err =:= closed ->
             % Directory might not exist
             case webdavfilez_mkdir:parent_dir(Url) of
                 {ok, UrlParent} ->

--- a/src/webdavfilez.erl
+++ b/src/webdavfilez.erl
@@ -219,7 +219,7 @@ put(Config, Url0, {filename, Size, Filename}, Opts) ->
                             Error
                     end;
                 {error, _} ->
-                    {error, 409}
+                    {error, Err}
             end;
         {error, 405} ->
             {error, epath};

--- a/src/webdavfilez_request.erl
+++ b/src/webdavfilez_request.erl
@@ -180,12 +180,13 @@ opts(Host) ->
     ].
 
 ssl_options(Host) ->
-    case z_ip_address:is_local_name(Host) of
-        true ->
-            [ {verify, verify_none} ];
-        false ->
-            tls_certificate_check:options(Host)
-    end.
+    [ {verify, verify_none} ].
+    % case z_ip_address:is_local_name(Host) of
+    %     true ->
+    %         [ {verify, verify_none} ];
+    %     false ->
+    %         tls_certificate_check:options(Host)
+    % end.
 
 basic_auth({Username, Password}) ->
     Username1 = unicode:characters_to_binary(Username),

--- a/src/webdavfilez_request.erl
+++ b/src/webdavfilez_request.erl
@@ -180,13 +180,12 @@ opts(Host) ->
     ].
 
 ssl_options(Host) ->
-    [ {verify, verify_none} ].
-    % case z_ip_address:is_local_name(Host) of
-    %     true ->
-    %         [ {verify, verify_none} ];
-    %     false ->
-    %         tls_certificate_check:options(Host)
-    % end.
+    case z_ip_address:is_local_name(Host) of
+        true ->
+            [ {verify, verify_none} ];
+        false ->
+            tls_certificate_check:options(Host)
+    end.
 
 basic_auth({Username, Password}) ->
     Username1 = unicode:characters_to_binary(Username),


### PR DESCRIPTION
The put request can return `{error, closed}` if the remote directory is missing.

Also fix a problem where the passed mime type could be a binary instead of a string, resulting in a httpc request error.