### PR TITLE
Fix an issue with httpc in Erlang > 24.0 not accepting an integer for Content-Length

### DIFF
--- a/src/webdavfilez.erl
+++ b/src/webdavfilez.erl
@@ -194,7 +194,7 @@ put(Config, Url, Payload) ->
 put(Config, Url0, {data, Data}, Opts) ->
     Url = map_url(Url0),
     Hs = [
-        {"Content-Length", size(Data)}
+        {"Content-Length", integer_to_list(size(Data))}
         | opts_to_headers(Opts)
     ],
     put_1(Config, Url, Hs, Data);


### PR DESCRIPTION
This used to work in OTP 24.0, but we started to see errors in OTP 24.2 and later.