### PR TITLE
Switch CI to OTP 26, 27, and 28

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [25,26,27]
+        otp_version: [26,27,28]
         os: [ubuntu-latest]
 
     container:


### PR DESCRIPTION
This pull request updates the OTP versions used in the GitHub Actions test workflow to ensure compatibility with newer releases.

Test workflow updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R21): Updated the OTP version matrix to remove version 25 and add version 28.