### PR TITLE
Fix license name in .src file

### DIFF
--- a/src/webdavfilez.app.src
+++ b/src/webdavfilez.app.src
@@ -20,6 +20,6 @@
   {env, [
       {max_connections, 20}
   ]},
-  {licenses, ["Apache 2.0"]},
+  {licenses, ["Apache-2.0"]},
   {links, [{"GitHub", "https://github.com/mworrell/webdavfilez"}]}
  ]}.


### PR DESCRIPTION
This pull request makes a small correction to the license identifier in the `src/webdavfilez.app.src` file, updating it to the standard SPDX format.

* Changed the license identifier from `"Apache 2.0"` to `"Apache-2.0"` for proper SPDX compliance.